### PR TITLE
open-uri update for ruby 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.3.0
-script:
-  - bundle exec rspec
-  - bundle exec yard stats | grep "100.00% documented"

--- a/elegant.gemspec
+++ b/elegant.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'prawn-manual_builder', '~> 0.2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
-  spec.add_development_dependency 'coveralls', '~> 0.8.10'
+  spec.add_development_dependency 'simplecov', '~> 0.21.0'
   spec.add_development_dependency 'pry-nav', '~> 0.2.4'
-  spec.add_development_dependency 'yard', '~> 0.9.9'
+  # spec.add_development_dependency 'yard', '~> 0.9.9'
 end

--- a/elegant.gemspec
+++ b/elegant.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency             'matrix', '~> 0.4.2'
   spec.add_dependency             'prawn', '~> 2.0'
 
   spec.add_development_dependency 'pdf-inspector', '~> 1.2'

--- a/elegant.gemspec
+++ b/elegant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'pdf-inspector', '~> 1.2'
   spec.add_development_dependency 'prawn-manual_builder', '~> 0.2.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'coveralls', '~> 0.8.10'
   spec.add_development_dependency 'pry-nav', '~> 0.2.4'

--- a/lib/elegant.rb
+++ b/lib/elegant.rb
@@ -1,3 +1,4 @@
+require 'matrix'
 require 'prawn'
 require 'elegant/document'
 

--- a/lib/elegant/footer.rb
+++ b/lib/elegant/footer.rb
@@ -1,4 +1,4 @@
-require 'open-uri' # for open(http://...)
+require 'open-uri' # for URI.open(http://...)
 module Elegant
   # Provides a uniform footer for each document containing the author in the
   # left side, an optional text in the middle, the page number in the right

--- a/lib/elegant/header.rb
+++ b/lib/elegant/header.rb
@@ -1,4 +1,4 @@
-require 'open-uri' # for open(http://...)
+require 'open-uri' # for URI.open(http://...)
 module Elegant
   # Provides a uniform header for each document containing a small watermark
   # image in the left side, room for an optional grey heading text in the right
@@ -84,7 +84,7 @@ module Elegant
       left = bounds.right - @logo_width - line_width
       top = bounds.top + @logo_height / 2
       options = {width: @logo_width, height: @logo_height, at: [left, top]}
-      image open(@logo[:url]), options
+      image URI.open(@logo[:url]), options
     rescue OpenURI::HTTPError, OpenSSL::SSL::SSLError, SocketError, Prawn::Errors::UnsupportedImageType
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,7 @@
 require 'simplecov'
-require 'coveralls'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
+  SimpleCov::Formatter::HTMLFormatter
 ]
 SimpleCov.start
 


### PR DESCRIPTION
- remove Travis (because there's no Travis currently for this repo)
- remove Coveralls (coveralls did not work with newer Ruby, when I tried)
- add Github Actions
- apply security patch of Rake
- "matrix" is a separate gem now